### PR TITLE
Add GameState model and integrate map loading

### DIFF
--- a/Scripts/BattleMap.gd
+++ b/Scripts/BattleMap.gd
@@ -1,9 +1,9 @@
 class_name BattleMap
 extends Node2D
 
-@export var grid_width := 8
-@export var grid_height := 5
+@export var map_path := "res://data/sample_map.json"
 var cell_size: int = Config.CELL_SIZE
+var state: GameState
 
 
 @onready var tile_container = $TileContainer
@@ -18,14 +18,16 @@ var visual_tiles: Dictionary = {}
 var selected_unit: Node = null
 var movement_range_tiles := []
 
-func _ready():
-	   # Offset the map so the first tile is fully visible at the origin
-		var half_cell := cell_size / 2
-		tile_container.position = Vector2(half_cell, half_cell)
-		unit_container.position = Vector2(half_cell, half_cell)
-
-		generate_grid()
-		spawn_test_unit()
+	func _ready():
+	state = GameState.new(map_path)
+	
+	# Offset the map so the first tile is fully visible at the origin
+	var half_cell := cell_size / 2
+	tile_container.position = Vector2(half_cell, half_cell)
+	unit_container.position = Vector2(half_cell, half_cell)
+	
+	generate_grid()
+	spawn_units()
 
 
 
@@ -85,23 +87,19 @@ func select_unit(unit: Node):
 
 
 func generate_grid():
-	for x in range(grid_width):
-		for y in range(grid_height):
-			var pos = Vector2i(x, y)
-			tiles[pos] = {
-				"walkable": true,
-				"occupied": false,
-				"effect": null,
-			}
-
-			var tile_instance = tile_scene.instantiate()
-			tile_instance.grid_pos = pos
-			tile_instance.cell_size = cell_size
-			tile_instance.update_position()
-			tile_container.add_child(tile_instance)
-
-
-			visual_tiles[pos] = tile_instance
+	for x in state.grid_width:
+	for y in state.grid_height:
+	var pos := Vector2i(x, y)
+	var data := state.tiles.get(pos, {})
+	tiles[pos] = data.duplicate()
+	
+	var tile_instance = tile_scene.instantiate()
+	tile_instance.grid_pos = pos
+	tile_instance.cell_size = cell_size
+	tile_instance.update_position()
+	tile_container.add_child(tile_instance)
+	
+	visual_tiles[pos] = tile_instance
 
 
 func to_world(grid_pos: Vector2i) -> Vector2:
@@ -111,9 +109,10 @@ func to_grid(world_pos: Vector2) -> Vector2i:
 	return Vector2i(floor(world_pos.x / cell_size), floor(world_pos.y / cell_size))
 	
 
-func spawn_test_unit():
+	func spawn_units():
+	for info in state.units:
 	var unit = unit_scene.instantiate()
-	unit.grid_pos = Vector2i(1, 1)
+	unit.grid_pos = Vector2i(info.get("x", 0), info.get("y", 0))
 	unit.cell_size = cell_size
-	unit.map = self  # Inject the reference to BattleMap
+	unit.map = self
 	unit_container.add_child(unit)

--- a/Scripts/model/GameState.gd
+++ b/Scripts/model/GameState.gd
@@ -1,0 +1,35 @@
+class_name GameState
+
+var grid_width: int
+var grid_height: int
+var tiles := {}
+var units := []
+
+func _init(map_path: String):
+	load_map(map_path)
+
+func load_map(path: String) -> void:
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		push_error("Failed to open map file: %s" % path)
+		return
+	var data = JSON.parse_string(file.get_as_text())
+	file.close()
+	grid_width = data.get("width", 0)
+	grid_height = data.get("height", 0)
+
+	var blocked := {}
+	for b in data.get("blocked_tiles", []):
+		blocked[Vector2i(b.get("x", 0), b.get("y", 0))] = true
+
+	tiles.clear()
+	for x in grid_width:
+		for y in grid_height:
+			var pos := Vector2i(x, y)
+			tiles[pos] = {
+				"walkable": !blocked.has(pos),
+				"occupied": false,
+				"effect": null
+			}
+
+	units = data.get("units", [])

--- a/data/sample_map.json
+++ b/data/sample_map.json
@@ -1,0 +1,10 @@
+{
+    "width": 8,
+    "height": 5,
+    "blocked_tiles": [
+        {"x": 3, "y": 2}
+    ],
+    "units": [
+        {"x": 1, "y": 1}
+    ]
+}


### PR DESCRIPTION
## Summary
- create `Scripts/model` with `GameState.gd`
- load map info from `data/sample_map.json`
- hold a `GameState` in `BattleMap` and spawn units from it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a031512ac832c8c63cdaeaea62c42