### PR TITLE
Implement simple battle frame mechanics

### DIFF
--- a/Scripts/battle_map.gd
+++ b/Scripts/battle_map.gd
@@ -14,18 +14,29 @@ var unit_scene := preload("res://Unit.tscn")
 
 var tiles: Dictionary = {}
 var visual_tiles: Dictionary = {}
+var units: Array = []
+var units_by_pos: Dictionary = {}
+var battle_timer: Timer
+var rng := RandomNumberGenerator.new()
 
 
 func _ready():
-	state = GameState.new(map_path)
+        state = GameState.new(map_path)
 		
 	# Offset the map so the first tile is fully visible at the origin
 	var half_cell := cell_size / 2
 	tile_container.position = Vector2(half_cell, half_cell)
 	unit_container.position = Vector2(half_cell, half_cell)
 
-	generate_grid()
-	spawn_units()
+        generate_grid()
+        spawn_units()
+        rng.seed = 1
+        battle_timer = Timer.new()
+        battle_timer.wait_time = 6.0
+        battle_timer.one_shot = false
+        add_child(battle_timer)
+        battle_timer.timeout.connect(_on_battle_frame)
+        battle_timer.start()
 
 func get_tile_node_at(pos: Vector2i) -> Node2D:
 		if visual_tiles.has(pos):
@@ -54,13 +65,72 @@ func world_to_cell(world_pos: Vector2) -> Vector2i:
 	)
 
 func cell_to_world(cell: Vector2i) -> Vector2:
-	return Vector2(cell) * cell_size + Vector2.ONE * (cell_size / 2.0)
+        return Vector2(cell) * cell_size + Vector2.ONE * (cell_size / 2.0)
 		
 
 func spawn_units():
-	for info in state.units:
-		var unit = unit_scene.instantiate()
-		unit.grid_pos = Vector2i(info.get("x", 0), info.get("y", 0))
-		unit.cell_size = cell_size
-		unit.map = self
-		unit_container.add_child(unit)
+        for info in state.units:
+                var unit: Unit = unit_scene.instantiate()
+                unit.cell_size = cell_size
+                unit.map = self
+                unit.setup(info)
+                unit_container.add_child(unit)
+                units.append(unit)
+                tiles[unit.grid_pos]["occupied"] = true
+                units_by_pos[unit.grid_pos] = unit
+
+func get_unit_at(pos: Vector2i) -> Unit:
+        return units_by_pos.get(pos)
+
+func can_move_to(pos: Vector2i) -> bool:
+        if !tiles.has(pos):
+                return false
+        var data = tiles[pos]
+        return data.get("walkable", true) and !data.get("occupied", false)
+
+func move_unit(unit: Unit, new_pos: Vector2i) -> void:
+        units_by_pos.erase(unit.grid_pos)
+        tiles[unit.grid_pos]["occupied"] = false
+        unit.grid_pos = new_pos
+        tiles[new_pos]["occupied"] = true
+        units_by_pos[new_pos] = unit
+
+func remove_unit(unit: Unit) -> void:
+        units_by_pos.erase(unit.grid_pos)
+        if tiles.has(unit.grid_pos):
+                tiles[unit.grid_pos]["occupied"] = false
+        units.erase(unit)
+        unit.queue_free()
+
+func _sort_units(a: Unit, b: Unit) -> bool:
+        if a.initiative == b.initiative:
+                return rng.randi() % 2 == 0
+        return a.initiative > b.initiative
+
+func _on_battle_frame() -> void:
+        if check_victory():
+                return
+        var active: Array = []
+        for u in units:
+                if u.alive:
+                        active.append(u)
+        active.sort_custom(self, "_sort_units")
+        for u in active:
+                u.take_turn()
+        check_victory()
+
+func check_victory() -> bool:
+        var ally := false
+        var enemy := false
+        for u in units:
+                if u.alive:
+                        if u.team == "ally":
+                                ally = true
+                        else:
+                                enemy = true
+        if !ally or !enemy:
+                if battle_timer:
+                        battle_timer.stop()
+                print("Battle finished")
+                return true
+        return false

--- a/Scripts/unit.gd
+++ b/Scripts/unit.gd
@@ -4,6 +4,15 @@ class_name Unit
 var cell_size: int = Config.CELL_SIZE
 var _grid_pos: Vector2i = Vector2i.ZERO
 
+var team: String = "ally"
+var health: int = 100
+var attack: int = 10
+var move_cd: int = 1
+var attack_cd: int = 2
+var initiative: int = 3
+var cooldown: int = 0
+var alive: bool = true
+
 @export var grid_pos: Vector2i:
 		get:
 				return _grid_pos
@@ -16,8 +25,8 @@ var map: BattleMap  # Set from battle_map.gd on spawn
 @onready var sprite = $Sprite2D
 
 func _ready():
-	update_position()
-	fit_to_tile()
+        update_position()
+        fit_to_tile()
 	
 func fit_to_tile():
 	if sprite.texture:
@@ -29,4 +38,57 @@ func fit_to_tile():
 
 
 func update_position():
-	position = grid_pos * cell_size
+        position = grid_pos * cell_size
+
+func setup(info: Dictionary) -> void:
+        grid_pos = Vector2i(info.get("x", 0), info.get("y", 0))
+        team = info.get("team", team)
+        health = info.get("health", health)
+        attack = info.get("attack", attack)
+        move_cd = int(info.get("move_cd", move_cd))
+        attack_cd = int(info.get("attack_cd", attack_cd))
+        initiative = int(info.get("initiative", initiative))
+
+func forward_dir() -> Vector2i:
+        return Vector2i(1, 0) if team == "ally" else Vector2i(-1, 0)
+
+func take_turn() -> void:
+        if !alive:
+                return
+        if cooldown > 0:
+                cooldown -= 1
+                return
+
+        var target = find_adjacent_enemy()
+        if target:
+                perform_attack(target)
+        else:
+                attempt_move_forward()
+
+func find_adjacent_enemy() -> Unit:
+        var dirs = [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]
+        for d in dirs:
+                var pos = grid_pos + d
+                var enemy: Unit = map.get_unit_at(pos)
+                if enemy and enemy.team != team and enemy.alive:
+                        return enemy
+        return null
+
+func perform_attack(target: Unit) -> void:
+        target.receive_damage(attack)
+        cooldown = attack_cd
+
+func receive_damage(amount: int) -> void:
+        health -= amount
+        if health <= 0:
+                die()
+
+func die() -> void:
+        alive = false
+        map.remove_unit(self)
+
+func attempt_move_forward() -> void:
+        var new_pos = grid_pos + forward_dir()
+        if map.can_move_to(new_pos):
+                map.move_unit(self, new_pos)
+        cooldown = move_cd

--- a/data/sample_map.json
+++ b/data/sample_map.json
@@ -1,10 +1,29 @@
 {
-	"width": 8,
-	"height": 5,
-	"blocked_tiles": [
-		{"x": 3, "y": 2}
-	],
-	"units": [
-		{"x": 1, "y": 1}
-	]
+"width": 8,
+"height": 5,
+"blocked_tiles": [
+{"x": 3, "y": 2}
+],
+"units": [
+{
+"x": 0,
+"y": 1,
+"team": "ally",
+"health": 100,
+"attack": 10,
+"move_cd": 1,
+"attack_cd": 2,
+"initiative": 3
+},
+{
+"x": 7,
+"y": 1,
+"team": "enemy",
+"health": 100,
+"attack": 10,
+"move_cd": 1,
+"attack_cd": 2,
+"initiative": 3
+}
+]
 }


### PR DESCRIPTION
## Summary
- extend `Unit` with health, cooldown, initiative and basic combat logic
- run a timer in `BattleMap` to process turns every 6 seconds
- spawn teams with stats from `sample_map.json`
- track units on the grid and end the battle when a side has no survivors

## Testing
- `python3 -m json.tool data/sample_map.json`


------
https://chatgpt.com/codex/tasks/task_e_684bcd6828e4832c8e967c2114617212