### PR TITLE
Add unit state components

### DIFF
--- a/Scripts/components/basic_attack_component.gd
+++ b/Scripts/components/basic_attack_component.gd
@@ -1,0 +1,26 @@
+extends Node
+class_name BasicAttackComponent
+
+@export var unit: Node
+@export var cooldown: CooldownComponent
+@export var damage: int = 1
+@export var range: int = 1
+@export var attack_cooldown_frames: int = 1
+
+func can_attack(target: Node) -> bool:
+	if target == null:
+		return false
+	if unit.map == null:
+		return false
+	if unit.grid_pos.distance_to(target.grid_pos) > range:
+		return false
+	return cooldown == null or cooldown.is_ready("attack")
+
+func attack(target: Node) -> bool:
+	if !can_attack(target):
+		return false
+	if cooldown:
+		cooldown.start("attack", attack_cooldown_frames)
+	if target.has_node("HealthComponent"):
+		target.get_node("HealthComponent").take_damage(damage)
+	return true

--- a/Scripts/components/basic_attack_component.gd.uid
+++ b/Scripts/components/basic_attack_component.gd.uid
@@ -1,0 +1,1 @@
+uid://a7le4mapyanw

--- a/Scripts/components/cooldown_component.gd
+++ b/Scripts/components/cooldown_component.gd
@@ -1,0 +1,17 @@
+extends Node
+class_name CooldownComponent
+
+var cooldowns: Dictionary = {}
+
+func tick() -> void:
+	for name in cooldowns.keys():
+		cooldowns[name] -= 1
+	for name in cooldowns.keys():
+		if cooldowns[name] <= 0:
+			cooldowns.erase(name)
+
+func is_ready(name: String) -> bool:
+	return !cooldowns.has(name)
+
+func start(name: String, frames: int) -> void:
+	cooldowns[name] = frames

--- a/Scripts/components/cooldown_component.gd.uid
+++ b/Scripts/components/cooldown_component.gd.uid
@@ -1,0 +1,1 @@
+uid://vbye5ofafdhy

--- a/Scripts/components/health_component.gd
+++ b/Scripts/components/health_component.gd
@@ -1,0 +1,21 @@
+extends Node
+class_name HealthComponent
+
+@export var max_health: int = 10
+var current_health: int
+
+signal died
+
+func _ready() -> void:
+	current_health = max_health
+
+func is_alive() -> bool:
+	return current_health > 0
+
+func take_damage(amount: int) -> void:
+	current_health = max(current_health - amount, 0)
+	if current_health == 0:
+		emit_signal("died")
+
+func heal(amount: int) -> void:
+	current_health = min(current_health + amount, max_health)

--- a/Scripts/components/health_component.gd.uid
+++ b/Scripts/components/health_component.gd.uid
@@ -1,0 +1,1 @@
+uid://802iyutpfzoc

--- a/Scripts/components/movement_component.gd
+++ b/Scripts/components/movement_component.gd
@@ -1,0 +1,21 @@
+extends Node
+class_name MovementComponent
+
+@export var unit: Node
+@export var cooldown: CooldownComponent
+@export var move_cooldown_frames: int = 1
+
+func request_move(delta: Vector2i) -> bool:
+	if cooldown and !cooldown.is_ready("move"):
+		return false
+	if unit == null:
+		return false
+	var target := unit.grid_pos + delta
+	if unit.map and unit.map.tiles.has(target):
+		var tile := unit.map.tiles[target]
+		if tile.get("walkable", true):
+			unit.grid_pos = target
+			if cooldown:
+				cooldown.start("move", move_cooldown_frames)
+			return true
+	return false

--- a/Scripts/components/movement_component.gd.uid
+++ b/Scripts/components/movement_component.gd.uid
@@ -1,0 +1,1 @@
+uid://j2cplr18nqsi

--- a/Scripts/components/priority_component.gd
+++ b/Scripts/components/priority_component.gd
@@ -1,0 +1,7 @@
+extends Node
+class_name PriorityComponent
+
+@export var move_before_attack: bool = false
+
+func should_move_before_attack() -> bool:
+	return move_before_attack

--- a/Scripts/components/priority_component.gd.uid
+++ b/Scripts/components/priority_component.gd.uid
@@ -1,0 +1,1 @@
+uid://9rt68jlqfw8w

--- a/Scripts/unit.gd
+++ b/Scripts/unit.gd
@@ -14,10 +14,19 @@ var _grid_pos: Vector2i = Vector2i.ZERO
 var map: BattleMap  # Set from battle_map.gd on spawn
 
 @onready var sprite = $Sprite2D
+@onready var cooldown: CooldownComponent = $CooldownComponent
+@onready var health: HealthComponent = $HealthComponent
+@onready var movement: MovementComponent = $MovementComponent
+@onready var attack: BasicAttackComponent = $BasicAttackComponent
+@onready var priority: PriorityComponent = $PriorityComponent
 
 func _ready():
 	update_position()
 	fit_to_tile()
+
+func tick() -> void:
+	if cooldown:
+		cooldown.tick()
 	
 func fit_to_tile():
 	if sprite.texture:

--- a/Unit.tscn
+++ b/Unit.tscn
@@ -1,7 +1,12 @@
-[gd_scene load_steps=4 format=3 uid="uid://ck142j3ewqutu"]
+[gd_scene load_steps=9 format=3 uid="uid://ck142j3ewqutu"]
 
 [ext_resource type="Script" uid="uid://dcifymsfxp4b6" path="res://Scripts/unit.gd" id="1_ypl2c"]
 [ext_resource type="Texture2D" uid="uid://c40cg7k0gkblf" path="res://Assets/elementals_wind_hashashin_FREE_v1.1/PNG/idle/idle_1.png" id="2_lqx2h"]
+[ext_resource type="Script" path="res://Scripts/components/cooldown_component.gd" id="3_cool"]
+[ext_resource type="Script" path="res://Scripts/components/health_component.gd" id="4_health"]
+[ext_resource type="Script" path="res://Scripts/components/movement_component.gd" id="5_move"]
+[ext_resource type="Script" path="res://Scripts/components/basic_attack_component.gd" id="6_attack"]
+[ext_resource type="Script" path="res://Scripts/components/priority_component.gd" id="7_priority"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_ctwoc"]
 
@@ -13,3 +18,18 @@ texture = ExtResource("2_lqx2h")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CapsuleShape2D_ctwoc")
+
+[node name="CooldownComponent" type="Node" parent="."]
+script = ExtResource("3_cool")
+
+[node name="HealthComponent" type="Node" parent="."]
+script = ExtResource("4_health")
+
+[node name="MovementComponent" type="Node" parent="."]
+script = ExtResource("5_move")
+
+[node name="BasicAttackComponent" type="Node" parent="."]
+script = ExtResource("6_attack")
+
+[node name="PriorityComponent" type="Node" parent="."]
+script = ExtResource("7_priority")


### PR DESCRIPTION
## Summary
- start component-based unit state system
- add health, attack, movement, cooldown, and priority components
- embed new components in `Unit` scene and script

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684cbb557358832c85de7c85e2bc0d66